### PR TITLE
Switcher Code

### DIFF
--- a/fw/include/zenith.h
+++ b/fw/include/zenith.h
@@ -9,6 +9,8 @@ Public-facing API for Zenith.
 
 // hardware callbacks
 void cb_zenith_init_hardware(void);
+int cb_zenith_read_controller_switch(void);
+void cb_zenith_switch_input(int index);
 void cb_zenith_read_buttons(btn_data_t *buttons);
 void cb_zenith_read_analog(analog_data_t *analog_data);
 // if ZTH_SEPARATE_CAL_READ, calibration will use this instead to read analog

--- a/fw/include/zenith/settings.h
+++ b/fw/include/zenith/settings.h
@@ -5,6 +5,9 @@
 #include "zenith/input/btn_remap.h"
 #include "zenith/input/stick.h"
 
+// Number of settings profiles
+#define PROFILE_COUNT 2
+
 // 512k from start of flash
 #define FLASH_OFFSET (512 * 1024)
 
@@ -33,7 +36,8 @@ typedef struct {
 
 typedef enum { SETTINGS_NONE, SETTINGS_COMMIT, SETTINGS_RESET } settings_cmd_t;
 
-extern zenith_settings_t _settings;
+extern zenith_settings_t _settings[PROFILE_COUNT];
+extern _Atomic volatile int _profile;
 extern _Atomic volatile settings_cmd_t _settings_cmd;
 
 void settings_core1_handle_commit();

--- a/fw/lib/comms/comms.c
+++ b/fw/lib/comms/comms.c
@@ -1,7 +1,7 @@
 #include "zenith/includes.h"
 
 void comms_init() {
-    switch (_settings.comms_mode) {
+    switch (_settings[_profile].comms_mode) {
     case COMMS_MODE_N64: {
         n64_init();
     } break;
@@ -13,7 +13,7 @@ void comms_init() {
 
 void comms_task(uint32_t timestamp, btn_data_t *buttons,
                 analog_data_t *analog) {
-    switch (_settings.comms_mode) {
+    switch (_settings[_profile].comms_mode) {
     case COMMS_MODE_N64: {
         n64_comms_task(timestamp, buttons, analog);
     } break;

--- a/fw/lib/input/btn_remap.c
+++ b/fw/lib/input/btn_remap.c
@@ -21,13 +21,13 @@ void apply_btn_remap(btn_remap_profile_t *remap_profile, btn_data_t *in,
 }
 
 void btn_remap_task(btn_data_t *in, btn_data_t *out) {
-    switch (_settings.comms_mode) {
+    switch (_settings[_profile].comms_mode) {
     case COMMS_MODE_N64: {
-        apply_btn_remap(&_settings.btn_remap_profile_n64, in, out);
+        apply_btn_remap(&_settings[_profile].btn_remap_profile_n64, in, out);
         break;
     }
     case COMMS_MODE_GAMECUBE: {
-        apply_btn_remap(&_settings.btn_remap_profile_gamecube, in, out);
+        apply_btn_remap(&_settings[_profile].btn_remap_profile_gamecube, in, out);
         break;
     }
     }

--- a/fw/lib/input/calib.c
+++ b/fw/lib/input/calib.c
@@ -123,13 +123,13 @@ void calibration_finish(void) {
     ax_t linearized_points_y[NUM_NOTCHES];
 
     linearize_cal(cleaned_points_x, cleaned_points_y, linearized_points_x,
-                  linearized_points_y, &(_settings.calib_results));
+                  linearized_points_y, &(_settings[_profile].calib_results));
 
     // Copy the linearized points we have just found to phobri's internal data
     // sturcture.
     for (int i = 0; i < NUM_NOTCHES; i++) {
-        _settings.calib_results.notch_points_x_in[i] = linearized_points_x[i];
-        _settings.calib_results.notch_points_y_in[i] = linearized_points_y[i];
+        _settings[_profile].calib_results.notch_points_x_in[i] = linearized_points_x[i];
+        _settings[_profile].calib_results.notch_points_y_in[i] = linearized_points_y[i];
         debug_print("Linearized point:  %d; (x,y) = (%f, %f)\n", i,
                     linearized_points_x[i], linearized_points_y[i]);
     }
@@ -141,21 +141,21 @@ void calibration_finish(void) {
         // angle; doing this will mess it up if the sensor is negative to go up
         // in Y; need to figure out the appropriate place in the code to
         // compensate for this
-        _settings.calib_results.notch_points_x_in[i] =
+        _settings[_profile].calib_results.notch_points_x_in[i] =
             (cleaned_points_x[i + 1] - cleaned_points_x[0]);
-        _settings.calib_results.notch_points_y_in[i] =
+        _settings[_profile].calib_results.notch_points_y_in[i] =
             (cleaned_points_y[i + 1] - cleaned_points_y[0]);
         debug_print("Notch Point in point:  %d; (x,y) = (%f, %f)\n", i,
-                    _settings.calib_results.notch_points_x_in[i],
-                    _settings.calib_results.notch_points_y_in[i]);
+                    _settings[_profile].calib_results.notch_points_x_in[i],
+                    _settings[_profile].calib_results.notch_points_y_in[i]);
     }
 #endif // ZTH_LINEARIZATON_EN
 
-    notch_calibrate(_settings.calib_results.notch_points_x_in,
-                    _settings.calib_results.notch_points_y_in,
-                    _settings.stick_config.notch_points_x,
-                    _settings.stick_config.notch_points_y,
-                    &(_settings.calib_results));
+    notch_calibrate(_settings[_profile].calib_results.notch_points_x_in,
+                    _settings[_profile].calib_results.notch_points_y_in,
+                    _settings[_profile].stick_config.notch_points_x,
+                    _settings[_profile].stick_config.notch_points_y,
+                    &(_settings[_profile].calib_results));
     debug_print("Calibrated!\n");
     /*debug_print("X coeffs: %f %f %f %f, Y coeffs: %f %f %f %f\n",
            _settings.calib_results.fit_coeffs_x[0],

--- a/fw/lib/input/stick.c
+++ b/fw/lib/input/stick.c
@@ -63,6 +63,6 @@ void stick_task(uint32_t timestamp, analog_data_t *in, analog_data_t *out) {
         return;
 
     cb_zenith_read_analog(in);
-    process_stick(in, out, _settings.gate_limiter_enable, &(_settings.calib_results),
-                  &(_settings.stick_config));
+    process_stick(in, out, _settings[_profile].gate_limiter_enable, &(_settings[_profile].calib_results),
+                  &(_settings[_profile].stick_config));
 }

--- a/fw/lib/usb/webusb.c
+++ b/fw/lib/usb/webusb.c
@@ -105,30 +105,30 @@ void webusb_command_processor(uint8_t *data) {
             debug_print("Notch out of range?\n");
             break;
         }
-        _settings.stick_config.notch_points_x[notch] =
+        _settings[_profile].stick_config.notch_points_x[notch] =
             INT_N_TO_AX((int8_t)data[2], 8);
-        _settings.stick_config.notch_points_y[notch] =
+        _settings[_profile].stick_config.notch_points_y[notch] =
             INT_N_TO_AX((int8_t)data[3], 8);
-        memcpy(_settings.stick_config.angle_deadzones + notch, data + 4,
+        memcpy(_settings[_profile].stick_config.angle_deadzones + notch, data + 4,
                sizeof(float));
         // recompute notch calibration
-        notch_calibrate(_settings.calib_results.notch_points_x_in,
-                        _settings.calib_results.notch_points_y_in,
-                        _settings.stick_config.notch_points_x,
-                        _settings.stick_config.notch_points_y,
-                        &(_settings.calib_results));
+        notch_calibrate(_settings[_profile].calib_results.notch_points_x_in,
+                        _settings[_profile].calib_results.notch_points_y_in,
+                        _settings[_profile].stick_config.notch_points_x,
+                        _settings[_profile].stick_config.notch_points_y,
+                        &(_settings[_profile].calib_results));
     } break;
     case WEBUSB_CMD_NOTCHES_GET: {
         debug_print("WebUSB: Got notch points GET command.\n");
         _webusb_out_buffer[0] = WEBUSB_CMD_NOTCHES_GET;
         for (int i = 0; i < NUM_NOTCHES; i++) {
             _webusb_out_buffer[i * 6 + 1] =
-                AX_TO_INT8(_settings.stick_config.notch_points_x[i]);
+                AX_TO_INT8(_settings[_profile].stick_config.notch_points_x[i]);
             _webusb_out_buffer[i * 6 + 2] =
-                AX_TO_INT8(_settings.stick_config.notch_points_y[i]);
+                AX_TO_INT8(_settings[_profile].stick_config.notch_points_y[i]);
 
             memcpy(_webusb_out_buffer + (i * 6 + 3),
-                   _settings.stick_config.angle_deadzones + i, sizeof(float));
+                   _settings[_profile].stick_config.angle_deadzones + i, sizeof(float));
         }
         if (webusb_ready_blocking(5000)) {
             tud_vendor_n_write(0, _webusb_out_buffer, 64);
@@ -143,10 +143,10 @@ void webusb_command_processor(uint8_t *data) {
         uint8_t bind = data[3];
         switch (c) {
         case COMMS_MODE_N64: {
-            _settings.btn_remap_profile_n64.p[btn] = bind;
+            _settings[_profile].btn_remap_profile_n64.p[btn] = bind;
         }
         case COMMS_MODE_GAMECUBE: {
-            _settings.btn_remap_profile_gamecube.p[btn] = bind;
+            _settings[_profile].btn_remap_profile_gamecube.p[btn] = bind;
             break;
         }
         }
@@ -160,13 +160,13 @@ void webusb_command_processor(uint8_t *data) {
         comms_mode_t c = (comms_mode_t)data[1];
         switch (c) {
         case COMMS_MODE_N64: {
-            memcpy(_webusb_out_buffer + 2, _settings.btn_remap_profile_n64.p,
+            memcpy(_webusb_out_buffer + 2, _settings[_profile].btn_remap_profile_n64.p,
                    32);
             break;
         }
         case COMMS_MODE_GAMECUBE: {
             memcpy(_webusb_out_buffer + 2,
-                   _settings.btn_remap_profile_gamecube.p, 32);
+                   _settings[_profile].btn_remap_profile_gamecube.p, 32);
             break;
         }
         }
@@ -178,13 +178,13 @@ void webusb_command_processor(uint8_t *data) {
 
     case WEBUSB_CMD_MAG_THRESH_SET: {
         debug_print("WebUSB: Got Magnitude Threshold SET command.\n");
-        memcpy(&_settings.stick_config.mag_threshold, data + 4, sizeof(float));
+        memcpy(&_settings[_profile].stick_config.mag_threshold, data + 4, sizeof(float));
     } break;
 
     case WEBUSB_CMD_MAG_THRESH_GET: {
         debug_print("WebUSB: Got Magnitude Threshold GET command.\n");
         _webusb_out_buffer[0] = WEBUSB_CMD_MAG_THRESH_GET;
-        memcpy(_webusb_out_buffer + 4, &_settings.stick_config.mag_threshold,
+        memcpy(_webusb_out_buffer + 4, &_settings[_profile].stick_config.mag_threshold,
                sizeof(float));
 
         if (webusb_ready_blocking(5000)) {
@@ -195,13 +195,13 @@ void webusb_command_processor(uint8_t *data) {
 
     case WEBUSB_CMD_GATE_LIMITER_SET: {
         debug_print("WebUSB: Got Gate Limiter SET command.\n");
-        memcpy(&_settings.gate_limiter_enable, data + 1, sizeof(bool));
+        memcpy(&_settings[_profile].gate_limiter_enable, data + 1, sizeof(bool));
     } break;
 
     case WEBUSB_CMD_GATE_LIMITER_GET: {
         debug_print("WebUSB: Got Gate Limiter GET command.\n");
         _webusb_out_buffer[0] = WEBUSB_CMD_GATE_LIMITER_GET;
-        memcpy(_webusb_out_buffer + 1, &_settings.gate_limiter_enable,
+        memcpy(_webusb_out_buffer + 1, &_settings[_profile].gate_limiter_enable,
                sizeof(bool));
 
         if (webusb_ready_blocking(5000)) {

--- a/fw/lib/zenith.c
+++ b/fw/lib/zenith.c
@@ -12,6 +12,10 @@ void zenith_loop_core0(void) {
     for (;;) {
         atomic_store(&_timestamp, time_us_32());
 
+#ifdef ZENITH_SWITCHER
+        atomic_store(&_profile, cb_zenith_read_controller_switch());
+#endif
+
         cb_zenith_read_buttons(&_buttons);
         btn_remap_task(&_buttons, &_buttons_processed);
 
@@ -27,9 +31,21 @@ void zenith_loop_core0(void) {
 
 void zenith_loop_core1(void) {
     cb_zenith_core1_init();
+#ifdef ZENITH_SWITCHER
+    int last_profile = _profile;
+#endif
 
     for (;;) {
         settings_core1_handle_commit();
+
+#ifdef ZENITH_SWITCHER
+        if (_profile != last_profile) {
+            last_profile = _profile;
+            multicore_lockout_start_blocking();
+            cb_zenith_switch_input(_profile);
+            multicore_lockout_end_blocking();
+        }
+#endif
 
         stick_task(atomic_load(&_timestamp), &_analog_data,
                    &_analog_data_processed);

--- a/fw/platforms/remapper/include/joybus_cons.h
+++ b/fw/platforms/remapper/include/joybus_cons.h
@@ -6,13 +6,18 @@
 #include <stdint.h>
 
 #include "zenith/comms/n64.h"
+#include "zenith/settings.h"
 
-#define JOYBUS_CTLR 2
+// Time to wait for a response, in microseconds. This value seems to work for most controllers.
+// This prevents things from freezing up if a controller is not connected or fails to respond once.
+#define JOYBUS_TIMEOUT 250
 
 uint joybus_cons_port_init(joybus_port_t *port, uint pin, PIO pio, int sm,
                            int offset);
+uint joybus_cons_port_change_pin(joybus_port_t *port, uint pin);
 
 void init_joybus();
+void change_joybus_index(int index);
 
 uint32_t read_joybus_ctlr();
 

--- a/fw/platforms/remapper/include/zenith_cfg.h
+++ b/fw/platforms/remapper/include/zenith_cfg.h
@@ -17,4 +17,16 @@
             0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0               \
     }
 
+// Uncomment to build the firmware for the switcher.
+// #define ZENITH_SWITCHER
+
+// GPIO pin to read the switch value from
+#define SWITCH_PIN 10
+
+// GPIO pin for the first controller
+#define JOYBUS_CTLR0 2
+
+// GPIO pin for the second controller
+#define JOYBUS_CTLR1 3
+
 #endif // ZENITH_CFG_H

--- a/fw/platforms/remapper/src/joybus_cons.c
+++ b/fw/platforms/remapper/src/joybus_cons.c
@@ -3,6 +3,8 @@
 #include <pico/time.h>
 #include <stdio.h>
 
+#include "zenith/includes.h"
+
 joybus_port_t cntlr_port;
 
 uint joybus_cons_port_init(joybus_port_t *port, uint pin, PIO pio, int sm,
@@ -29,11 +31,23 @@ uint joybus_cons_port_init(joybus_port_t *port, uint pin, PIO pio, int sm,
     return offset;
 }
 
+uint joybus_cons_port_change_pin(joybus_port_t *port, uint pin) {
+    port->pin = pin;
+    port->config =
+        joybus_program_get_config(port->pio, port->sm, port->offset, pin);
+
+    joybus_program_send_init(port->pio, port->sm, port->offset, port->pin,
+                             &port->config);
+
+    return port->offset;
+}
+
 void init_joybus() {
     // We are just going to claim PIO1
-    joybus_cons_port_init(&cntlr_port, JOYBUS_CTLR, pio1, -1, -1);
-    gpio_pull_up(JOYBUS_CTLR);
+    joybus_cons_port_init(&cntlr_port, JOYBUS_CTLR0, pio1, -1, -1);
+    gpio_pull_up(JOYBUS_CTLR0);
 
+#ifdef SEND_PROBE
     // Send status byte
     uint32_t data_shifted = (PROBE << 24) | (1 << 23);
     // printf("putting %d\n", data_shifted);
@@ -58,6 +72,7 @@ void init_joybus() {
         }
         got_response = true;
     }
+#endif
 
     joybus_program_send_init((&cntlr_port)->pio, (&cntlr_port)->sm,
                              (&cntlr_port)->offset, (&cntlr_port)->pin,
@@ -66,15 +81,36 @@ void init_joybus() {
     return;
 }
 
+void change_joybus_index(int index) {
+    uint pin = JOYBUS_CTLR0;
+    if (index == 1)
+        pin = JOYBUS_CTLR1;
+    joybus_cons_port_change_pin(&cntlr_port, pin);
+    gpio_pull_up(pin);
+
+    joybus_program_send_init((&cntlr_port)->pio, (&cntlr_port)->sm,
+                             (&cntlr_port)->offset, (&cntlr_port)->pin,
+                             &(&cntlr_port)->config);
+}
+
 uint32_t read_joybus_ctlr() {
     uint32_t data_shifted = (POLL << 24) | (1 << 23);
     pio_sm_put_blocking((&cntlr_port)->pio, (&cntlr_port)->sm, data_shifted);
 
+#ifdef JOYBUS_TIMEOUT
+    sleep_us(JOYBUS_TIMEOUT);
+#endif
+
     int byte_cnt = 0;
     uint32_t ctlr_word = 0;
     while (byte_cnt < 4) {
+#ifdef JOYBUS_TIMEOUT
+        uint8_t temp_data =
+            pio_sm_get((&cntlr_port)->pio, (&cntlr_port)->sm);
+#else
         uint8_t temp_data =
             pio_sm_get_blocking((&cntlr_port)->pio, (&cntlr_port)->sm);
+#endif
         ctlr_word >>= 8;
         ctlr_word |= (temp_data << 24);
         byte_cnt++;

--- a/fw/platforms/remapper/src/main.c
+++ b/fw/platforms/remapper/src/main.c
@@ -5,6 +5,7 @@
 
 #include "zenith/comms/n64.h"
 #include "zenith/utilities/running_avg.h"
+#include "zenith/includes.h"
 
 void setup_gpio_input(uint8_t gpio) {
     gpio_init(gpio);
@@ -23,6 +24,18 @@ void cb_zenith_init_hardware(void) {
         setup_gpio_input(i);
     }
     init_joybus();
+}
+
+void cb_zenith_switch_controller_input(int index) {
+    change_joybus_index(index);
+}
+
+int cb_zenith_read_controller_switch() {
+    return gpio_get(SWITCH_PIN) ? 1 : 0;
+}
+
+void cb_zenith_switch_input(int index) {
+    change_joybus_index(index);
 }
 
 void cb_zenith_read_buttons(btn_data_t *buttons) {


### PR DESCRIPTION
Firmware changes for the remapper so that it can switch between two different controllers, each with a separate remapping profile. By default, the two controllers are connected to GPIO 2 and 3, while the switch (toggling between 3.3V and GND) is connected to GPIO 10. Enable the switcher firmware by uncommenting `#define ZENITH_SWITCHER` in `fw/platforms/remapper/include/zenith_cfg.h`.